### PR TITLE
Port tests to criterion

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,13 @@
+project('ringfs', 'c',
+  version : '0.1',
+  default_options : ['warning_level=3'])
+
+ringfs = declare_dependency(
+  sources: files(
+    'ringfs.c',
+  ),
+  include_directories: include_directories('.')
+)
+
+subdir('test_new')
+

--- a/test_new/flashsim.c
+++ b/test_new/flashsim.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2014 Kosma Moczek <kosma@cloudyourcar.com>
+ * This program is free software. It comes without any warranty, to the extent
+ * permitted by applicable law. You can redistribute it and/or modify it under
+ * the terms of the Do What The Fuck You Want To Public License, Version 2, as
+ * published by Sam Hocevar. See the COPYING file for more details.
+ */
+
+#include "flashsim.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#ifdef FLASHSIM_LOG
+#define logprintf(args...) printf(args)
+#else
+#define logprintf(args...) do {} while (0)
+#endif
+
+struct flashsim {
+    int size;
+    int sector_size;
+
+    FILE *fh;
+};
+
+struct flashsim *flashsim_open(const char *name, int size, int sector_size)
+{
+    struct flashsim *sim = malloc(sizeof(struct flashsim));
+
+    sim->size = size;
+    sim->sector_size = sector_size;
+    sim->fh = fopen(name, "wb+");
+    assert(sim->fh != NULL);
+    assert(ftruncate(fileno(sim->fh), size) == 0);
+
+    // Populate file with 0xFF to mimic a real empty flash
+    void *empty = malloc(sim->sector_size);
+    assert(empty != NULL);
+    memset(empty, 0xff, sim->sector_size);
+
+    for (int address=0; address<size; address+=sector_size) {
+        assert(fwrite(empty, 1, sim->sector_size, sim->fh) == (size_t) sim->sector_size);
+    }
+
+    free(empty);
+
+    return sim;
+}
+
+void flashsim_close(struct flashsim *sim)
+{
+    fclose(sim->fh);
+    free(sim);
+}
+
+void flashsim_sector_erase(struct flashsim *sim, int addr)
+{
+    int sector_start = addr - (addr % sim->sector_size);
+    logprintf("flashsim_erase  (0x%08x) * erasing sector at 0x%08x\n", addr, sector_start);
+
+    void *empty = malloc(sim->sector_size);
+    memset(empty, 0xff, sim->sector_size);
+
+    assert(fseek(sim->fh, sector_start, SEEK_SET) == 0);
+    assert(fwrite(empty, 1, sim->sector_size, sim->fh) == (size_t) sim->sector_size);
+
+    free(empty);
+}
+
+void flashsim_read(struct flashsim *sim, int addr, uint8_t *buf, int len)
+{
+    assert(fseek(sim->fh, addr, SEEK_SET) == 0);
+    assert(fread(buf, 1, len, sim->fh) == (size_t) len);
+
+    logprintf("flashsim_read   (0x%08x) = %d bytes [ ", addr, len);
+    for (int i=0; i<len; i++) {
+        logprintf("%02x ", buf[i]);
+        if (i == 15) {
+            logprintf("... ");
+            break;
+        }
+    }
+    logprintf("]\n");
+}
+
+void flashsim_program(struct flashsim *sim, int addr, const uint8_t *buf, int len)
+{
+    logprintf("flashsim_program(0x%08x) + %d bytes [ ", addr, len);
+    for (int i=0; i<len; i++) {
+        logprintf("%02x ", buf[i]);
+        if (i == 15) {
+            logprintf("... ");
+            break;
+        }
+    }
+    logprintf("]\n");
+
+    uint8_t *data = malloc(len);
+
+    assert(fseek(sim->fh, addr, SEEK_SET) == 0);
+    assert(fread(data, 1, len, sim->fh) == (size_t) len);
+
+    for (int i=0; i<(int) len; i++)
+        data[i] &= buf[i];
+
+    assert(fseek(sim->fh, addr, SEEK_SET) == 0);
+    assert(fwrite(data, 1, len, sim->fh) == (size_t) len);
+
+    free(data);
+}
+
+/* vim: set ts=4 sw=4 et: */

--- a/test_new/flashsim.h
+++ b/test_new/flashsim.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2014 Kosma Moczek <kosma@cloudyourcar.com>
+ * This program is free software. It comes without any warranty, to the extent
+ * permitted by applicable law. You can redistribute it and/or modify it under
+ * the terms of the Do What The Fuck You Want To Public License, Version 2, as
+ * published by Sam Hocevar. See the COPYING file for more details.
+ */
+
+#ifndef FLASHSIM_H
+#define FLASHSIM_H
+
+#include <stdint.h>
+#include <unistd.h>
+
+struct flashsim;
+
+struct flashsim *flashsim_open(const char *name, int size, int sector_size);
+void flashsim_close(struct flashsim *sim);
+
+void flashsim_sector_erase(struct flashsim *sim, int addr);
+void flashsim_read(struct flashsim *sim, int addr, uint8_t *buf, int len);
+void flashsim_program(struct flashsim *sim, int addr, const uint8_t *buf, int len);
+
+#endif
+
+/* vim: set ts=4 sw=4 et: */

--- a/test_new/fuzzer.py
+++ b/test_new/fuzzer.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import random
+
+from pyflashsim import FlashSim
+from pyringfs import RingFSFlashPartition, RingFS
+
+
+def compare(a, b):
+    if a != b:
+        print(">>> %s != %s" % (a, b))
+    return a == b
+
+
+class FuzzRun(object):
+
+    def __init__(self, name, version, object_size, sector_size, total_sectors, sector_offset, sector_count):
+
+        print("FuzzRun[%s]: v=%08x os=%d ss=%d ts=%d so=%d sc=%d" % (name, version, object_size, sector_size,
+                total_sectors, sector_offset, sector_count))
+
+        sim = FlashSim(name, total_sectors*sector_size, sector_size)
+
+        def op_sector_erase(flash, address):
+            sim.sector_erase(address)
+            return 0
+
+        def op_program(flash, address, data):
+            sim.program(address, data)
+            return len(data)
+
+        def op_read(flash, address, size):
+            return sim.read(address, size)
+
+        self.version = version
+        self.object_size = object_size
+
+        self.flash = RingFSFlashPartition(sector_size, sector_offset, sector_count,
+                op_sector_erase, op_program, op_read)
+        self.fs = RingFS(self.flash, self.version, self.object_size)
+
+    def run(self):
+
+        self.fs.format()
+        self.fs.dump()
+
+        def do_append():
+            self.fs.append('x'*self.object_size)
+
+        def do_fetch():
+            self.fs.fetch()
+
+        def do_rewind():
+            self.fs.rewind()
+
+        def do_discard():
+            self.fs.discard()
+
+        for i in range(1000):
+            fun = random.choice([do_append]*100 + [do_fetch]*100 + [do_rewind]*10 + [do_discard]*10)
+            print(i, fun.__name__)
+            fun()
+
+            # consistency check
+            newfs = RingFS(self.flash, self.version, self.object_size)
+            try:
+                assert newfs.scan() == 0
+                assert compare(newfs.ringfs.read.sector, self.fs.ringfs.read.sector)
+                assert compare(newfs.ringfs.read.slot, self.fs.ringfs.read.slot)
+                assert compare(newfs.ringfs.write.sector, self.fs.ringfs.write.sector)
+                assert compare(newfs.ringfs.write.slot, self.fs.ringfs.write.slot)
+            except AssertionError:
+                print("self.fs:")
+                self.fs.dump()
+                print("newfs:")
+                newfs.dump()
+                raise
+
+
+sector_size = random.randint(16, 256)
+total_sectors = random.randint(2, 8)
+sector_offset = random.randint(0, total_sectors-2)
+sector_count = random.randint(2, total_sectors-sector_offset)
+version = random.randint(0, 0xffffffff)
+object_size = random.randint(1, sector_size-8)
+
+f = FuzzRun('tests/fuzzer.sim', version, object_size, sector_size, total_sectors, sector_offset, sector_count)
+f.run()

--- a/test_new/meson.build
+++ b/test_new/meson.build
@@ -1,0 +1,10 @@
+t = executable('test_ringfs',
+  sources: files(
+    'flashsim.c',
+    'tests.c',
+  ),
+  include_directories: include_directories('.'),
+  dependencies: [ringfs, dependency('criterion')]
+)
+
+test(t.name(), t)

--- a/test_new/pyflashsim.py
+++ b/test_new/pyflashsim.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from sharedlibrary import GenericLibrary
+from ctypes import *
+
+
+class libflashsim(GenericLibrary):
+    dllname = 'tests/flashsim.so'
+    functions = [
+        ['flashsim_open', [c_char_p, c_int, c_int], c_void_p],
+        ['flashsim_sector_erase', [c_void_p, c_int], None],
+        ['flashsim_read', [c_void_p, c_int, c_void_p, c_int], None],
+        ['flashsim_program', [c_void_p, c_int, c_void_p, c_int], None],
+        ['flashsim_close', [c_void_p], None],
+    ]
+
+
+class FlashSim(object):
+
+    def __init__(self, name, size, sector_size):
+        self.libflashsim = libflashsim()
+        self.sim = self.libflashsim.flashsim_open(name.encode("utf-8") ,size, sector_size)
+
+    def sector_erase(self, addr):
+        self.libflashsim.flashsim_sector_erase(self.sim, addr)
+
+    def read(self, addr, size):
+        buf = create_string_buffer(size)
+        self.libflashsim.flashsim_read(self.sim, addr, buf, size)
+        return buf.raw
+
+    def program(self, addr, data):
+        self.libflashsim.flashsim_program(self.sim, addr, data, len(data))
+
+    def __del__(self):
+        self.libflashsim.flashsim_close(self.sim)

--- a/test_new/pyringfs.py
+++ b/test_new/pyringfs.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+from sharedlibrary import GenericLibrary
+from ctypes import *
+
+
+# forward declaration
+class StructRingFSFlashPartition(Structure):
+    pass
+
+op_sector_erase_t = CFUNCTYPE(c_int, POINTER(StructRingFSFlashPartition), c_int)
+op_program_t = CFUNCTYPE(c_ssize_t, POINTER(StructRingFSFlashPartition), c_int, c_void_p, c_size_t)
+op_read_t = CFUNCTYPE(c_ssize_t, POINTER(StructRingFSFlashPartition), c_int, c_void_p, c_size_t)
+
+StructRingFSFlashPartition._fields_ = [
+    ('sector_size', c_int),
+    ('sector_offset', c_int),
+    ('sector_count', c_int),
+
+    ('sector_erase', op_sector_erase_t),
+    ('program', op_program_t),
+    ('read', op_read_t),
+]
+
+class StructRingFSLoc(Structure):
+    _fields_ = [
+        ('sector', c_int),
+        ('slot', c_int),
+    ]
+
+class StructRingFS(Structure):
+    _fields_ = [
+        ('flash', POINTER(StructRingFSFlashPartition)),
+        ('version', c_uint32),
+        ('object_size', c_int),
+        ('slots_per_sector', c_int),
+
+        ('read', StructRingFSLoc),
+        ('write', StructRingFSLoc),
+        ('cursor', StructRingFSLoc),
+    ]
+
+
+class libringfs(GenericLibrary):
+    dllname = './ringfs.so'
+    functions = [
+        ['ringfs_init', [POINTER(StructRingFS), POINTER(StructRingFSFlashPartition), c_uint32, c_int], None],
+        ['ringfs_format', [POINTER(StructRingFS)], c_int],
+        ['ringfs_scan', [POINTER(StructRingFS)], c_int],
+        ['ringfs_capacity', [POINTER(StructRingFS)], c_int],
+        ['ringfs_count_estimate', [POINTER(StructRingFS)], c_int],
+        ['ringfs_count_exact', [POINTER(StructRingFS)], c_int],
+        ['ringfs_append', [POINTER(StructRingFS), c_void_p], c_int],
+        ['ringfs_append_ex', [POINTER(StructRingFS), c_void_p, c_int], c_int],
+        ['ringfs_fetch', [POINTER(StructRingFS), c_void_p], c_int],
+        ['ringfs_fetch_ex', [POINTER(StructRingFS), c_void_p], c_int],
+        ['ringfs_discard', [POINTER(StructRingFS)], c_int],
+        ['ringfs_rewind', [POINTER(StructRingFS)], c_int],
+        ['ringfs_dump', [c_void_p, POINTER(StructRingFS)], None],
+    ]
+
+
+class RingFSFlashPartition(object):
+
+    def __init__(self, sector_size, sector_offset, sector_count, sector_erase, program, read):
+
+        def op_sector_erase(flash, address):
+            sector_erase(flash, address)
+            return 0
+
+        def op_program(flash, address, data, size):
+            program(flash, address, string_at(data, size))
+            return size
+
+        def op_read(flash, address, buf, size):
+            data = read(flash, address, size)
+            memmove(buf, data, size)
+            return size
+
+        self.struct = StructRingFSFlashPartition(sector_size, sector_offset, sector_count,
+                op_sector_erase_t(op_sector_erase),
+                op_program_t(op_program),
+                op_read_t(op_read))
+
+
+class RingFS(object):
+
+    def __init__(self, flash, version, object_size):
+        self.libringfs = libringfs()
+        self.ringfs = StructRingFS()
+        self.flash = flash.struct
+        self.libringfs.ringfs_init(byref(self.ringfs), byref(self.flash), version, object_size)
+        self.object_size = object_size
+
+    def format(self):
+        self.libringfs.ringfs_format(byref(self.ringfs))
+
+    def scan(self):
+        return self.libringfs.ringfs_scan(byref(self.ringfs))
+
+    def capacity(self):
+        return self.libringfs.ringfs_capacity(byref(self.ringfs))
+
+    def count_estimate(self):
+        return self.libringfs.ringfs_count_estimate(byref(self.ringfs))
+
+    def count_exact(self):
+        return self.libringfs.ringfs_count_exact(byref(self.ringfs))
+
+    def append(self, obj):
+        self.libringfs.ringfs_append(byref(self.ringfs), obj)
+
+    def append_ex(self, obj, size):
+        self.libringfs.ringfs_append_ex(byref(self.ringfs), obj, size)
+
+    def fetch(self):
+        obj = create_string_buffer(self.object_size)
+        self.libringfs.ringfs_append(byref(self.ringfs), obj)
+        return obj.raw
+
+    def fetch_ex(self, size):
+        obj = create_string_buffer(size)
+        self.libringfs.ringfs_fetch_ex(byref(self.ringfs), obj, size)
+        return obj.raw
+
+    def discard(self):
+        self.libringfs.ringfs_discard(byref(self.ringfs))
+
+    def rewind(self):
+        self.libringfs.ringfs_rewind(byref(self.ringfs))
+
+    def dump(self):
+        import ctypes
+        libc = ctypes.CDLL(None)
+        libc.fdopen.argtypes = [ctypes.c_int, ctypes.c_char_p]
+        libc.fdopen.restype = ctypes.c_void_p
+        cstdout = libc.fdopen(sys.stdout.fileno(), b"w")
+        self.libringfs.ringfs_dump(cstdout, byref(self.ringfs))
+
+__all__ = [
+    'StructRingFSFlashPartition',
+    'RingFS',
+]

--- a/test_new/sharedlibrary.py
+++ b/test_new/sharedlibrary.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from ctypes import CDLL
+
+class GenericLibrary(CDLL):
+
+    def __init__(self, *args, **kwargs):
+        super(GenericLibrary, self).__init__(self.dllname, *args, **kwargs)
+
+        for name, argtypes, restype in self.functions:
+            getattr(self, name).argtypes = argtypes
+            getattr(self, name).restype = restype

--- a/test_new/tests.c
+++ b/test_new/tests.c
@@ -265,8 +265,8 @@ Test(test_suite_ringfs, test_ringfs_append)
     }
 }
 
-#if 0
-START_TEST(test_ringfs_discard)
+
+Test(test_suite_ringfs, test_ringfs_discard)
 {
     printf("# test_ringfs_discard\n");
 
@@ -310,9 +310,9 @@ START_TEST(test_ringfs_discard)
     assert_loc_equiv_to_offset(&fs, &fs.write, 4);
     assert_scan_integrity(&fs);
 }
-END_TEST
 
-START_TEST(test_ringfs_capacity)
+
+Test(test_suite_ringfs, test_ringfs_capacity)
 {
     printf("# test_ringfs_capacity\n");
 
@@ -323,9 +323,9 @@ START_TEST(test_ringfs_capacity)
     int sectors = flash.sector_count;
     cr_assert_eq(ringfs_capacity(&fs), (sectors-1) * slots_per_sector);
 }
-END_TEST
 
-START_TEST(test_ringfs_count)
+
+Test(test_suite_ringfs, test_ringfs_count)
 {
     printf("# test_ringfs_count\n");
 
@@ -389,9 +389,9 @@ START_TEST(test_ringfs_count)
     fs.write = (struct ringfs_loc) { 0, 0 };
     cr_assert_eq(ringfs_count_estimate(&fs), 1);
 }
-END_TEST
 
-START_TEST(test_ringfs_overflow)
+
+Test(test_suite_ringfs, test_ringfs_overflow)
 {
     printf("# test_ringfs_overflow\n");
 
@@ -424,42 +424,6 @@ START_TEST(test_ringfs_overflow)
         assert_scan_integrity(&fs);
     }
 }
-END_TEST
 
-Suite *ringfs_suite(void)
-{
-    Suite *s = suite_create ("ringfs");
-    TCase *tc;
-
-    tc = tcase_create("flashsim");
-    tcase_add_test(tc, test_flashsim);
-    suite_add_tcase(s, tc);
-
-    tc = tcase_create("ringfs");
-    tcase_add_checked_fixture(tc, fixture_flashsim_setup, fixture_flashsim_teardown);
-    tcase_add_test(tc, test_ringfs_format);
-    tcase_add_test(tc, test_ringfs_scan);
-    tcase_add_test(tc, test_ringfs_append);
-    tcase_add_test(tc, test_ringfs_discard);
-    tcase_add_test(tc, test_ringfs_capacity);
-    tcase_add_test(tc, test_ringfs_count);
-    tcase_add_test(tc, test_ringfs_overflow);
-    suite_add_tcase(s, tc);
-
-    return s;
-}
-
-int main()
-{
-    int number_failed;
-    Suite *s = ringfs_suite();
-    SRunner *sr = srunner_create(s);
-    srunner_run_all(sr, CK_NORMAL);
-    number_failed = srunner_ntests_failed(sr);
-    srunner_free(sr);
-    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
-}
 
 /* vim: set ts=4 sw=4 et: */
-
-#endif

--- a/test_new/tests.c
+++ b/test_new/tests.c
@@ -20,13 +20,11 @@
 #include "flashsim.h"
 
 /* Flashsim tests. */
-static void fixture_flashsim_setup(void);
-static void fixture_flashsim_teardown(void);
-Test(test_flashsim, basic, .init = fixture_flashsim_setup, .fini=fixture_flashsim_teardown)
+Test(test_flashsim, basic)
 {
     printf("# test_flashsim\n");
 
-    struct flashsim *smallsim = flashsim_open("tests/test.sim", 1024, 16);
+    struct flashsim *smallsim = flashsim_open("test.sim", 1024, 16);
     uint8_t buf[48];
     uint8_t data[16];
 
@@ -39,11 +37,11 @@ Test(test_flashsim, basic, .init = fixture_flashsim_setup, .fini=fixture_flashsi
 
     flashsim_read(smallsim, 0, buf, 48);
     for (int i=0; i<16; i++)
-        ck_assert_int_eq(buf[i], 0xff);
+        cr_assert_eq(buf[i], 0xff);
     for (int i=16; i<32; i++)
-        ck_assert_int_eq(buf[i], 0x5a);
+        cr_assert_eq(buf[i], 0x5a);
     for (int i=32; i<48; i++)
-        ck_assert_int_eq(buf[i], 0xff);
+        cr_assert_eq(buf[i], 0xff);
 
     memset(data, 0x01, 16);
     flashsim_program(smallsim, 0, data, 16);
@@ -53,15 +51,14 @@ Test(test_flashsim, basic, .init = fixture_flashsim_setup, .fini=fixture_flashsi
 
     flashsim_read(smallsim, 0, buf, 48);
     for (int i=0; i<16; i++)
-        ck_assert_int_eq(buf[i], 0x01);
+        cr_assert_eq(buf[i], 0x01);
     for (int i=16; i<32; i++)
-        ck_assert_int_eq(buf[i], 0xff);
+        cr_assert_eq(buf[i], 0xff);
     for (int i=32; i<48; i++)
-        ck_assert_int_eq(buf[i], 0x10);
+        cr_assert_eq(buf[i], 0x10);
 
     free(smallsim);
 }
-END_TEST
 
 /* Flash simulator + MTD partition fixture. */
 
@@ -129,6 +126,8 @@ static void fixture_flashsim_teardown(void)
 }
 
 /* RingFS tests. */
+
+#if 0
 
 #define DEFAULT_VERSION 0x000000042
 typedef struct
@@ -465,3 +464,4 @@ int main()
 
 /* vim: set ts=4 sw=4 et: */
 
+#endif

--- a/test_new/tests.c
+++ b/test_new/tests.c
@@ -1,0 +1,467 @@
+/*
+ * Copyright © 2014 Kosma Moczek <kosma@cloudyourcar.com>
+ * This program is free software. It comes without any warranty, to the extent
+ * permitted by applicable law. You can redistribute it and/or modify it under
+ * the terms of the Do What The Fuck You Want To Public License, Version 2, as
+ * published by Sam Hocevar. See the COPYING file for more details.
+ */
+
+#include <criterion/criterion.h>
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <check.h>
+
+#include "ringfs.h"
+#include "flashsim.h"
+
+/* Flashsim tests. */
+static void fixture_flashsim_setup(void);
+static void fixture_flashsim_teardown(void);
+Test(test_flashsim, basic, .init = fixture_flashsim_setup, .fini=fixture_flashsim_teardown)
+{
+    printf("# test_flashsim\n");
+
+    struct flashsim *smallsim = flashsim_open("tests/test.sim", 1024, 16);
+    uint8_t buf[48];
+    uint8_t data[16];
+
+    flashsim_sector_erase(smallsim, 0);
+    flashsim_sector_erase(smallsim, 16);
+    flashsim_sector_erase(smallsim, 32);
+
+    memset(data, 0x5a, 16);
+    flashsim_program(smallsim, 16, data, 16);
+
+    flashsim_read(smallsim, 0, buf, 48);
+    for (int i=0; i<16; i++)
+        ck_assert_int_eq(buf[i], 0xff);
+    for (int i=16; i<32; i++)
+        ck_assert_int_eq(buf[i], 0x5a);
+    for (int i=32; i<48; i++)
+        ck_assert_int_eq(buf[i], 0xff);
+
+    memset(data, 0x01, 16);
+    flashsim_program(smallsim, 0, data, 16);
+    memset(data, 0x10, 16);
+    flashsim_program(smallsim, 32, data, 16);
+    flashsim_sector_erase(smallsim, 16);
+
+    flashsim_read(smallsim, 0, buf, 48);
+    for (int i=0; i<16; i++)
+        ck_assert_int_eq(buf[i], 0x01);
+    for (int i=16; i<32; i++)
+        ck_assert_int_eq(buf[i], 0xff);
+    for (int i=32; i<48; i++)
+        ck_assert_int_eq(buf[i], 0x10);
+
+    free(smallsim);
+}
+END_TEST
+
+/* Flash simulator + MTD partition fixture. */
+
+static struct flashsim *sim;
+
+static int op_sector_erase(struct ringfs_flash_partition *flash, int address)
+{
+    (void) flash;
+    flashsim_sector_erase(sim, address);
+    return 0;
+}
+
+static ssize_t op_program(struct ringfs_flash_partition *flash, int address, const void *data, size_t size)
+{
+    (void) flash;
+    flashsim_program(sim, address, data, size);
+    return size;
+}
+
+static ssize_t op_read(struct ringfs_flash_partition *flash, int address, void *data, size_t size)
+{
+    (void) flash;
+    flashsim_read(sim, address, data, size);
+    return size;
+}
+
+static void op_log(struct ringfs_flash_partition *flash, const char *fmt, ...)
+{
+    (void) flash;
+    va_list args;
+    va_start(args, fmt);
+    printf("[ringfs] ");
+    vprintf(fmt, args);
+    printf("\n");
+    va_end(args);
+}
+
+/*
+ * A really small filesystem: 3 slots per sector, 15 slots total.
+ * Has the benefit of causing frequent wraparounds, potentially finding
+ * more bugs.
+ */
+static struct ringfs_flash_partition flash = {
+    .sector_size = 32,
+    .sector_offset = 4,
+    .sector_count = 6,
+
+    .sector_erase = op_sector_erase,
+    .program = op_program,
+    .read = op_read,
+    .log = op_log
+};
+
+static void fixture_flashsim_setup(void)
+{
+    sim = flashsim_open("tests/ringfs.sim",
+            flash.sector_size * (flash.sector_offset + flash.sector_count),
+            flash.sector_size);
+}
+
+static void fixture_flashsim_teardown(void)
+{
+    flashsim_close(sim);
+    sim = NULL;
+}
+
+/* RingFS tests. */
+
+#define DEFAULT_VERSION 0x000000042
+typedef struct
+{
+    uint8_t data[4];
+} object_t;
+#define SECTOR_HEADER_SIZE 8
+#define SLOT_HEADER_SIZE 4
+
+static void assert_loc_equiv_to_offset(const struct ringfs *fs, const struct ringfs_loc *loc, int offset)
+{
+    int loc_offset = loc->sector * fs->slots_per_sector + loc->slot;
+    ck_assert_int_eq(offset, loc_offset);
+}
+
+static void assert_scan_integrity(const struct ringfs *fs)
+{
+    struct ringfs newfs;
+    ringfs_init(&newfs, fs->flash, fs->version, fs->object_size);
+    ck_assert(ringfs_scan(&newfs) == 0);
+    ck_assert_int_eq(newfs.read.sector, fs->read.sector);
+    ck_assert_int_eq(newfs.read.slot, fs->read.slot);
+    ck_assert_int_eq(newfs.write.sector, fs->write.sector);
+    ck_assert_int_eq(newfs.write.slot, fs->write.slot);
+}
+
+START_TEST(test_ringfs_format)
+{
+    printf("# test_ringfs_format\n");
+
+    struct ringfs fs1;
+    printf("## ringfs_init()\n");
+    ringfs_init(&fs1, &flash, DEFAULT_VERSION, sizeof(object_t));
+    printf("## ringfs_format()\n");
+    ringfs_format(&fs1);
+}
+END_TEST
+
+START_TEST(test_ringfs_scan)
+{
+    printf("# test_ringfs_scan\n");
+
+    /* first format a filesystem */
+    struct ringfs fs1;
+    printf("## ringfs_init()\n");
+    ringfs_init(&fs1, &flash, DEFAULT_VERSION, sizeof(object_t));
+    printf("## ringfs_format()\n");
+    ringfs_format(&fs1);
+
+    /* now try to scan it */
+    struct ringfs fs2;
+    printf("## ringfs_init()\n");
+    ringfs_init(&fs2, &flash, DEFAULT_VERSION, sizeof(object_t));
+    printf("## ringfs_scan()\n");
+    ck_assert(ringfs_scan(&fs2) == 0);
+
+    /* this is an empty FS, should start with this: */
+    ck_assert_int_eq(fs2.slots_per_sector, (flash.sector_size-SECTOR_HEADER_SIZE)/(SLOT_HEADER_SIZE+sizeof(object_t)));
+    assert_loc_equiv_to_offset(&fs2, &fs2.read, 0);
+    assert_loc_equiv_to_offset(&fs2, &fs2.cursor, 0);
+    assert_loc_equiv_to_offset(&fs2, &fs2.write, 0);
+
+    /* now insert some objects */
+    ck_assert(ringfs_append(&fs2, (int[]) { 0x11 }) == 0);
+    ck_assert(ringfs_append(&fs2, (int[]) { 0x22 }) == 0);
+    ck_assert(ringfs_append(&fs2, (int[]) { 0x33 }) == 0);
+
+    /* rescan */
+    printf("## ringfs_scan()\n");
+    ck_assert(ringfs_scan(&fs2) == 0);
+
+    /* make sure the objects are there */
+    ck_assert(ringfs_count_exact(&fs2) == 3);
+
+    /* scan should fail if we supply a different version */
+    struct ringfs fs3;
+    printf("## ringfs_init()\n");
+    ringfs_init(&fs3, &flash, DEFAULT_VERSION+1, sizeof(object_t));
+    printf("## ringfs_scan()\n");
+    ck_assert(ringfs_scan(&fs3) != 0);
+}
+END_TEST
+
+START_TEST(test_ringfs_append)
+{
+    printf("# test_ringfs_append\n");
+
+    /* first format a filesystem */
+    int obj;
+    struct ringfs fs;
+    printf("## ringfs_init()\n");
+    ringfs_init(&fs, &flash, DEFAULT_VERSION, sizeof(object_t));
+    printf("## ringfs_format()\n");
+    ringfs_format(&fs);
+
+    /* fetches before appends should not change anything */
+    for (int i=0; i<3; i++) {
+        printf("## ringfs_fetch()\n");
+        ck_assert(ringfs_fetch(&fs, &obj) < 0);
+    }
+    assert_loc_equiv_to_offset(&fs, &fs.read, 0);
+    assert_loc_equiv_to_offset(&fs, &fs.write, 0);
+    assert_loc_equiv_to_offset(&fs, &fs.cursor, 0);
+    assert_scan_integrity(&fs);
+
+    /* now we're brave and we write some data */
+    for (int i=0; i<3; i++) {
+        printf("## ringfs_append()\n");
+        ringfs_append(&fs, (int[]) { 0x11*(i+1) });
+
+        /* make sure the write head has advanced */
+        assert_loc_equiv_to_offset(&fs, &fs.write, i+1);
+        assert_scan_integrity(&fs);
+    }
+
+    /* now we fetch at it. */
+    for (int i=0; i<3; i++) {
+        printf("## ringfs_fetch()\n");
+        ck_assert(ringfs_fetch(&fs, &obj) == 0);
+        ck_assert_int_eq(obj, 0x11*(i+1));
+
+        /* make sure the cursor head has advanced */
+        assert_loc_equiv_to_offset(&fs, &fs.cursor, i+1);
+    }
+    /* there should be no data left */
+    ck_assert(ringfs_fetch(&fs, &obj) < 0);
+
+    /* test the rewind. */
+    ck_assert(ringfs_rewind(&fs) == 0);
+    assert_loc_equiv_to_offset(&fs, &fs.cursor, 0);
+
+    /* try to read the objects once again. */
+    for (int i=0; i<3; i++) {
+        printf("## ringfs_fetch()\n");
+        ck_assert(ringfs_fetch(&fs, &obj) == 0);
+        ck_assert_int_eq(obj, 0x11*(i+1));
+    }
+}
+END_TEST
+
+START_TEST(test_ringfs_discard)
+{
+    printf("# test_ringfs_discard\n");
+
+    struct ringfs fs;
+    printf("## ringfs_init()\n");
+    ringfs_init(&fs, &flash, DEFAULT_VERSION, sizeof(object_t));
+    printf("## ringfs_format()\n");
+    ringfs_format(&fs);
+
+    /* write some records */
+    for (int i=0; i<4; i++) {
+        printf("## ringfs_append()\n");
+        ringfs_append(&fs, (int[]) { 0x11*(i+1) });
+        assert_scan_integrity(&fs);
+    }
+    /* read some of them */
+    int obj;
+    for (int i=0; i<2; i++) {
+        printf("## ringfs_fetch()\n");
+        ck_assert(ringfs_fetch(&fs, &obj) == 0);
+        ck_assert_int_eq(obj, 0x11*(i+1));
+    }
+    /* discard whatever was read */
+    ck_assert(ringfs_discard(&fs) == 0);
+    assert_scan_integrity(&fs);
+    /* make sure we're consistent */
+    assert_loc_equiv_to_offset(&fs, &fs.read, 2);
+    assert_loc_equiv_to_offset(&fs, &fs.cursor, 2);
+    assert_loc_equiv_to_offset(&fs, &fs.write, 4);
+
+    /* read the rest of the records */
+    for (int i=2; i<4; i++) {
+        printf("## ringfs_fetch()\n");
+        ck_assert(ringfs_fetch(&fs, &obj) == 0);
+        ck_assert_int_eq(obj, 0x11*(i+1));
+    }
+    /* discard them */
+    ck_assert(ringfs_discard(&fs) == 0);
+    assert_loc_equiv_to_offset(&fs, &fs.read, 4);
+    assert_loc_equiv_to_offset(&fs, &fs.cursor, 4);
+    assert_loc_equiv_to_offset(&fs, &fs.write, 4);
+    assert_scan_integrity(&fs);
+}
+END_TEST
+
+START_TEST(test_ringfs_capacity)
+{
+    printf("# test_ringfs_capacity\n");
+
+    struct ringfs fs;
+    ringfs_init(&fs, &flash, DEFAULT_VERSION, sizeof(object_t));
+
+    int slots_per_sector = (flash.sector_size-SECTOR_HEADER_SIZE)/(SLOT_HEADER_SIZE+sizeof(object_t));
+    int sectors = flash.sector_count;
+    ck_assert_int_eq(ringfs_capacity(&fs), (sectors-1) * slots_per_sector);
+}
+END_TEST
+
+START_TEST(test_ringfs_count)
+{
+    printf("# test_ringfs_count\n");
+
+    int obj;
+    struct ringfs fs;
+    ringfs_init(&fs, &flash, DEFAULT_VERSION, sizeof(object_t));
+    ringfs_format(&fs);
+    ck_assert(ringfs_count_exact(&fs) == 0);
+
+    printf("## write some records\n");
+    for (int i=0; i<10; i++)
+        ringfs_append(&fs, (int[]) { 0x11*(i+1) });
+    ck_assert_int_eq(ringfs_count_exact(&fs), 10);
+    ck_assert_int_eq(ringfs_count_estimate(&fs), 10);
+
+    printf("## rescan\n");
+    ck_assert(ringfs_scan(&fs) == 0);
+    ck_assert_int_eq(ringfs_count_exact(&fs), 10);
+    ck_assert_int_eq(ringfs_count_estimate(&fs), 10);
+
+    printf("## append more records\n");
+    for (int i=10; i<13; i++)
+        ringfs_append(&fs, (int[]) { 0x11*(i+1) });
+    ck_assert_int_eq(ringfs_count_exact(&fs), 13);
+    ck_assert_int_eq(ringfs_count_estimate(&fs), 13);
+
+    printf("## fetch some objects without discard\n");
+    for (int i=0; i<4; i++) {
+        ck_assert(ringfs_fetch(&fs, &obj) == 0);
+        ck_assert_int_eq(obj, 0x11*(i+1));
+    }
+    ck_assert_int_eq(ringfs_count_exact(&fs), 13);
+    ck_assert_int_eq(ringfs_count_estimate(&fs), 13);
+
+    printf("## rescan\n");
+    ck_assert(ringfs_scan(&fs) == 0);
+    ck_assert_int_eq(ringfs_count_exact(&fs), 13);
+    ck_assert_int_eq(ringfs_count_estimate(&fs), 13);
+
+    printf("## fetch some objects with discard\n");
+    for (int i=0; i<4; i++) {
+        ck_assert(ringfs_fetch(&fs, &obj) == 0);
+        ck_assert_int_eq(obj, 0x11*(i+1));
+    }
+    ck_assert_int_eq(ringfs_count_exact(&fs), 13);
+    ck_assert_int_eq(ringfs_count_estimate(&fs), 13);
+    ck_assert(ringfs_discard(&fs) == 0);
+    ck_assert_int_eq(ringfs_count_exact(&fs), 9);
+    ck_assert_int_eq(ringfs_count_estimate(&fs), 9);
+
+    printf("## fill the segment\n");
+    int count = fs.slots_per_sector - 1;
+    for (int i=0; i<count; i++)
+        ringfs_append(&fs, (int[]) { 0x42 });
+    ck_assert_int_eq(ringfs_count_exact(&fs), 9+count);
+    ck_assert_int_eq(ringfs_count_estimate(&fs), 9+count);
+
+    printf("## extra synthetic tests for estimation\n");
+    /* wrapping around */
+    fs.read = (struct ringfs_loc) { fs.flash->sector_count - 1, fs.slots_per_sector - 1 };
+    fs.write = (struct ringfs_loc) { 0, 0 };
+    ck_assert_int_eq(ringfs_count_estimate(&fs), 1);
+}
+END_TEST
+
+START_TEST(test_ringfs_overflow)
+{
+    printf("# test_ringfs_overflow\n");
+
+    printf("## format\n");
+    struct ringfs fs;
+    ringfs_init(&fs, &flash, DEFAULT_VERSION, sizeof(object_t));
+    ringfs_format(&fs);
+
+    int capacity = ringfs_capacity(&fs);
+
+    printf("## fill filesystem to the brim\n");
+    for (int i=0; i<capacity; i++)
+        ringfs_append(&fs, (int[]) { i });
+    ck_assert_int_eq(ringfs_count_exact(&fs), capacity);
+    assert_scan_integrity(&fs);
+
+    /* won't hurt to stress it a little bit! */
+    for (int round=0; round<3; round++) {
+        printf("## add one more object\n");
+        ringfs_append(&fs, (int[]) { 0x42 });
+        /* should kill one entire sector to make space */
+        ck_assert_int_eq(ringfs_count_exact(&fs), capacity - fs.slots_per_sector + 1);
+        assert_scan_integrity(&fs);
+
+        printf("## fill back up to the sector capacity\n");
+        for (int i=0; i<fs.slots_per_sector-1; i++)
+            ringfs_append(&fs, (int[]) { i });
+
+        ck_assert_int_eq(ringfs_count_exact(&fs), capacity);
+        assert_scan_integrity(&fs);
+    }
+}
+END_TEST
+
+Suite *ringfs_suite(void)
+{
+    Suite *s = suite_create ("ringfs");
+    TCase *tc;
+
+    tc = tcase_create("flashsim");
+    tcase_add_test(tc, test_flashsim);
+    suite_add_tcase(s, tc);
+
+    tc = tcase_create("ringfs");
+    tcase_add_checked_fixture(tc, fixture_flashsim_setup, fixture_flashsim_teardown);
+    tcase_add_test(tc, test_ringfs_format);
+    tcase_add_test(tc, test_ringfs_scan);
+    tcase_add_test(tc, test_ringfs_append);
+    tcase_add_test(tc, test_ringfs_discard);
+    tcase_add_test(tc, test_ringfs_capacity);
+    tcase_add_test(tc, test_ringfs_count);
+    tcase_add_test(tc, test_ringfs_overflow);
+    suite_add_tcase(s, tc);
+
+    return s;
+}
+
+int main()
+{
+    int number_failed;
+    Suite *s = ringfs_suite();
+    SRunner *sr = srunner_create(s);
+    srunner_run_all(sr, CK_NORMAL);
+    number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+/* vim: set ts=4 sw=4 et: */
+

--- a/test_new/tests.c
+++ b/test_new/tests.c
@@ -208,8 +208,8 @@ Test(test_suite_ringfs, test_ringfs_scan)
     printf("## ringfs_scan()\n");
     cr_assert(ringfs_scan(&fs3) != 0);
 }
-#if 0
-START_TEST(test_ringfs_append)
+
+Test(test_suite_ringfs, test_ringfs_append)
 {
     printf("# test_ringfs_append\n");
 
@@ -264,8 +264,8 @@ START_TEST(test_ringfs_append)
         cr_assert_eq(obj, 0x11*(i+1));
     }
 }
-END_TEST
 
+#if 0
 START_TEST(test_ringfs_discard)
 {
     printf("# test_ringfs_discard\n");

--- a/test_new/tests.c
+++ b/test_new/tests.c
@@ -114,7 +114,7 @@ static struct ringfs_flash_partition flash = {
 
 static void fixture_flashsim_setup(void)
 {
-    sim = flashsim_open("tests/ringfs.sim",
+    sim = flashsim_open("ringfs.sim",
             flash.sector_size * (flash.sector_offset + flash.sector_count),
             flash.sector_size);
 }
@@ -127,8 +127,6 @@ static void fixture_flashsim_teardown(void)
 
 /* RingFS tests. */
 
-#if 0
-
 #define DEFAULT_VERSION 0x000000042
 typedef struct
 {
@@ -140,21 +138,23 @@ typedef struct
 static void assert_loc_equiv_to_offset(const struct ringfs *fs, const struct ringfs_loc *loc, int offset)
 {
     int loc_offset = loc->sector * fs->slots_per_sector + loc->slot;
-    ck_assert_int_eq(offset, loc_offset);
+    cr_assert_eq(offset, loc_offset);
 }
 
 static void assert_scan_integrity(const struct ringfs *fs)
 {
     struct ringfs newfs;
     ringfs_init(&newfs, fs->flash, fs->version, fs->object_size);
-    ck_assert(ringfs_scan(&newfs) == 0);
-    ck_assert_int_eq(newfs.read.sector, fs->read.sector);
-    ck_assert_int_eq(newfs.read.slot, fs->read.slot);
-    ck_assert_int_eq(newfs.write.sector, fs->write.sector);
-    ck_assert_int_eq(newfs.write.slot, fs->write.slot);
+    cr_assert(ringfs_scan(&newfs) == 0);
+    cr_assert_eq(newfs.read.sector, fs->read.sector);
+    cr_assert_eq(newfs.read.slot, fs->read.slot);
+    cr_assert_eq(newfs.write.sector, fs->write.sector);
+    cr_assert_eq(newfs.write.slot, fs->write.slot);
 }
 
-START_TEST(test_ringfs_format)
+TestSuite(test_suite_ringfs, .init = fixture_flashsim_setup, .fini=fixture_flashsim_teardown);
+
+Test(test_suite_ringfs, ringtest_ringfs_format)
 {
     printf("# test_ringfs_format\n");
 
@@ -164,8 +164,7 @@ START_TEST(test_ringfs_format)
     printf("## ringfs_format()\n");
     ringfs_format(&fs1);
 }
-END_TEST
-
+#if 0
 START_TEST(test_ringfs_scan)
 {
     printf("# test_ringfs_scan\n");
@@ -209,7 +208,6 @@ START_TEST(test_ringfs_scan)
     printf("## ringfs_scan()\n");
     ck_assert(ringfs_scan(&fs3) != 0);
 }
-END_TEST
 
 START_TEST(test_ringfs_append)
 {

--- a/test_new/tests.c
+++ b/test_new/tests.c
@@ -164,8 +164,8 @@ Test(test_suite_ringfs, ringtest_ringfs_format)
     printf("## ringfs_format()\n");
     ringfs_format(&fs1);
 }
-#if 0
-START_TEST(test_ringfs_scan)
+
+Test(test_suite_ringfs, test_ringfs_scan)
 {
     printf("# test_ringfs_scan\n");
 
@@ -181,34 +181,34 @@ START_TEST(test_ringfs_scan)
     printf("## ringfs_init()\n");
     ringfs_init(&fs2, &flash, DEFAULT_VERSION, sizeof(object_t));
     printf("## ringfs_scan()\n");
-    ck_assert(ringfs_scan(&fs2) == 0);
+    cr_assert(ringfs_scan(&fs2) == 0);
 
     /* this is an empty FS, should start with this: */
-    ck_assert_int_eq(fs2.slots_per_sector, (flash.sector_size-SECTOR_HEADER_SIZE)/(SLOT_HEADER_SIZE+sizeof(object_t)));
+    cr_assert_eq(fs2.slots_per_sector, (flash.sector_size-SECTOR_HEADER_SIZE)/(SLOT_HEADER_SIZE+sizeof(object_t)));
     assert_loc_equiv_to_offset(&fs2, &fs2.read, 0);
     assert_loc_equiv_to_offset(&fs2, &fs2.cursor, 0);
     assert_loc_equiv_to_offset(&fs2, &fs2.write, 0);
 
     /* now insert some objects */
-    ck_assert(ringfs_append(&fs2, (int[]) { 0x11 }) == 0);
-    ck_assert(ringfs_append(&fs2, (int[]) { 0x22 }) == 0);
-    ck_assert(ringfs_append(&fs2, (int[]) { 0x33 }) == 0);
+    cr_assert(ringfs_append(&fs2, (int[]) { 0x11 }) == 0);
+    cr_assert(ringfs_append(&fs2, (int[]) { 0x22 }) == 0);
+    cr_assert(ringfs_append(&fs2, (int[]) { 0x33 }) == 0);
 
     /* rescan */
     printf("## ringfs_scan()\n");
-    ck_assert(ringfs_scan(&fs2) == 0);
+    cr_assert(ringfs_scan(&fs2) == 0);
 
     /* make sure the objects are there */
-    ck_assert(ringfs_count_exact(&fs2) == 3);
+    cr_assert(ringfs_count_exact(&fs2) == 3);
 
     /* scan should fail if we supply a different version */
     struct ringfs fs3;
-    printf("## ringfs_init()\n");
+    printf("## ringfs_init()\n"); 
     ringfs_init(&fs3, &flash, DEFAULT_VERSION+1, sizeof(object_t));
     printf("## ringfs_scan()\n");
-    ck_assert(ringfs_scan(&fs3) != 0);
+    cr_assert(ringfs_scan(&fs3) != 0);
 }
-
+#if 0
 START_TEST(test_ringfs_append)
 {
     printf("# test_ringfs_append\n");
@@ -224,7 +224,7 @@ START_TEST(test_ringfs_append)
     /* fetches before appends should not change anything */
     for (int i=0; i<3; i++) {
         printf("## ringfs_fetch()\n");
-        ck_assert(ringfs_fetch(&fs, &obj) < 0);
+        cr_assert(ringfs_fetch(&fs, &obj) < 0);
     }
     assert_loc_equiv_to_offset(&fs, &fs.read, 0);
     assert_loc_equiv_to_offset(&fs, &fs.write, 0);
@@ -244,24 +244,24 @@ START_TEST(test_ringfs_append)
     /* now we fetch at it. */
     for (int i=0; i<3; i++) {
         printf("## ringfs_fetch()\n");
-        ck_assert(ringfs_fetch(&fs, &obj) == 0);
-        ck_assert_int_eq(obj, 0x11*(i+1));
+        cr_assert(ringfs_fetch(&fs, &obj) == 0);
+        cr_assert_eq(obj, 0x11*(i+1));
 
         /* make sure the cursor head has advanced */
         assert_loc_equiv_to_offset(&fs, &fs.cursor, i+1);
     }
     /* there should be no data left */
-    ck_assert(ringfs_fetch(&fs, &obj) < 0);
+    cr_assert(ringfs_fetch(&fs, &obj) < 0);
 
     /* test the rewind. */
-    ck_assert(ringfs_rewind(&fs) == 0);
+    cr_assert(ringfs_rewind(&fs) == 0);
     assert_loc_equiv_to_offset(&fs, &fs.cursor, 0);
 
     /* try to read the objects once again. */
     for (int i=0; i<3; i++) {
         printf("## ringfs_fetch()\n");
-        ck_assert(ringfs_fetch(&fs, &obj) == 0);
-        ck_assert_int_eq(obj, 0x11*(i+1));
+        cr_assert(ringfs_fetch(&fs, &obj) == 0);
+        cr_assert_eq(obj, 0x11*(i+1));
     }
 }
 END_TEST
@@ -286,11 +286,11 @@ START_TEST(test_ringfs_discard)
     int obj;
     for (int i=0; i<2; i++) {
         printf("## ringfs_fetch()\n");
-        ck_assert(ringfs_fetch(&fs, &obj) == 0);
-        ck_assert_int_eq(obj, 0x11*(i+1));
+        cr_assert(ringfs_fetch(&fs, &obj) == 0);
+        cr_assert_eq(obj, 0x11*(i+1));
     }
     /* discard whatever was read */
-    ck_assert(ringfs_discard(&fs) == 0);
+    cr_assert(ringfs_discard(&fs) == 0);
     assert_scan_integrity(&fs);
     /* make sure we're consistent */
     assert_loc_equiv_to_offset(&fs, &fs.read, 2);
@@ -300,11 +300,11 @@ START_TEST(test_ringfs_discard)
     /* read the rest of the records */
     for (int i=2; i<4; i++) {
         printf("## ringfs_fetch()\n");
-        ck_assert(ringfs_fetch(&fs, &obj) == 0);
-        ck_assert_int_eq(obj, 0x11*(i+1));
+        cr_assert(ringfs_fetch(&fs, &obj) == 0);
+        cr_assert_eq(obj, 0x11*(i+1));
     }
     /* discard them */
-    ck_assert(ringfs_discard(&fs) == 0);
+    cr_assert(ringfs_discard(&fs) == 0);
     assert_loc_equiv_to_offset(&fs, &fs.read, 4);
     assert_loc_equiv_to_offset(&fs, &fs.cursor, 4);
     assert_loc_equiv_to_offset(&fs, &fs.write, 4);
@@ -321,7 +321,7 @@ START_TEST(test_ringfs_capacity)
 
     int slots_per_sector = (flash.sector_size-SECTOR_HEADER_SIZE)/(SLOT_HEADER_SIZE+sizeof(object_t));
     int sectors = flash.sector_count;
-    ck_assert_int_eq(ringfs_capacity(&fs), (sectors-1) * slots_per_sector);
+    cr_assert_eq(ringfs_capacity(&fs), (sectors-1) * slots_per_sector);
 }
 END_TEST
 
@@ -333,61 +333,61 @@ START_TEST(test_ringfs_count)
     struct ringfs fs;
     ringfs_init(&fs, &flash, DEFAULT_VERSION, sizeof(object_t));
     ringfs_format(&fs);
-    ck_assert(ringfs_count_exact(&fs) == 0);
+    cr_assert(ringfs_count_exact(&fs) == 0);
 
     printf("## write some records\n");
     for (int i=0; i<10; i++)
         ringfs_append(&fs, (int[]) { 0x11*(i+1) });
-    ck_assert_int_eq(ringfs_count_exact(&fs), 10);
-    ck_assert_int_eq(ringfs_count_estimate(&fs), 10);
+    cr_assert_eq(ringfs_count_exact(&fs), 10);
+    cr_assert_eq(ringfs_count_estimate(&fs), 10);
 
     printf("## rescan\n");
-    ck_assert(ringfs_scan(&fs) == 0);
-    ck_assert_int_eq(ringfs_count_exact(&fs), 10);
-    ck_assert_int_eq(ringfs_count_estimate(&fs), 10);
+    cr_assert(ringfs_scan(&fs) == 0);
+    cr_assert_eq(ringfs_count_exact(&fs), 10);
+    cr_assert_eq(ringfs_count_estimate(&fs), 10);
 
     printf("## append more records\n");
     for (int i=10; i<13; i++)
         ringfs_append(&fs, (int[]) { 0x11*(i+1) });
-    ck_assert_int_eq(ringfs_count_exact(&fs), 13);
-    ck_assert_int_eq(ringfs_count_estimate(&fs), 13);
+    cr_assert_eq(ringfs_count_exact(&fs), 13);
+    cr_assert_eq(ringfs_count_estimate(&fs), 13);
 
     printf("## fetch some objects without discard\n");
     for (int i=0; i<4; i++) {
-        ck_assert(ringfs_fetch(&fs, &obj) == 0);
-        ck_assert_int_eq(obj, 0x11*(i+1));
+        cr_assert(ringfs_fetch(&fs, &obj) == 0);
+        cr_assert_eq(obj, 0x11*(i+1));
     }
-    ck_assert_int_eq(ringfs_count_exact(&fs), 13);
-    ck_assert_int_eq(ringfs_count_estimate(&fs), 13);
+    cr_assert_eq(ringfs_count_exact(&fs), 13);
+    cr_assert_eq(ringfs_count_estimate(&fs), 13);
 
     printf("## rescan\n");
-    ck_assert(ringfs_scan(&fs) == 0);
-    ck_assert_int_eq(ringfs_count_exact(&fs), 13);
-    ck_assert_int_eq(ringfs_count_estimate(&fs), 13);
+    cr_assert(ringfs_scan(&fs) == 0);
+    cr_assert_eq(ringfs_count_exact(&fs), 13);
+    cr_assert_eq(ringfs_count_estimate(&fs), 13);
 
     printf("## fetch some objects with discard\n");
     for (int i=0; i<4; i++) {
-        ck_assert(ringfs_fetch(&fs, &obj) == 0);
-        ck_assert_int_eq(obj, 0x11*(i+1));
+        cr_assert(ringfs_fetch(&fs, &obj) == 0);
+        cr_assert_eq(obj, 0x11*(i+1));
     }
-    ck_assert_int_eq(ringfs_count_exact(&fs), 13);
-    ck_assert_int_eq(ringfs_count_estimate(&fs), 13);
-    ck_assert(ringfs_discard(&fs) == 0);
-    ck_assert_int_eq(ringfs_count_exact(&fs), 9);
-    ck_assert_int_eq(ringfs_count_estimate(&fs), 9);
+    cr_assert_eq(ringfs_count_exact(&fs), 13);
+    cr_assert_eq(ringfs_count_estimate(&fs), 13);
+    cr_assert(ringfs_discard(&fs) == 0);
+    cr_assert_eq(ringfs_count_exact(&fs), 9);
+    cr_assert_eq(ringfs_count_estimate(&fs), 9);
 
     printf("## fill the segment\n");
     int count = fs.slots_per_sector - 1;
     for (int i=0; i<count; i++)
         ringfs_append(&fs, (int[]) { 0x42 });
-    ck_assert_int_eq(ringfs_count_exact(&fs), 9+count);
-    ck_assert_int_eq(ringfs_count_estimate(&fs), 9+count);
+    cr_assert_eq(ringfs_count_exact(&fs), 9+count);
+    cr_assert_eq(ringfs_count_estimate(&fs), 9+count);
 
     printf("## extra synthetic tests for estimation\n");
     /* wrapping around */
     fs.read = (struct ringfs_loc) { fs.flash->sector_count - 1, fs.slots_per_sector - 1 };
     fs.write = (struct ringfs_loc) { 0, 0 };
-    ck_assert_int_eq(ringfs_count_estimate(&fs), 1);
+    cr_assert_eq(ringfs_count_estimate(&fs), 1);
 }
 END_TEST
 
@@ -405,7 +405,7 @@ START_TEST(test_ringfs_overflow)
     printf("## fill filesystem to the brim\n");
     for (int i=0; i<capacity; i++)
         ringfs_append(&fs, (int[]) { i });
-    ck_assert_int_eq(ringfs_count_exact(&fs), capacity);
+    cr_assert_eq(ringfs_count_exact(&fs), capacity);
     assert_scan_integrity(&fs);
 
     /* won't hurt to stress it a little bit! */
@@ -413,14 +413,14 @@ START_TEST(test_ringfs_overflow)
         printf("## add one more object\n");
         ringfs_append(&fs, (int[]) { 0x42 });
         /* should kill one entire sector to make space */
-        ck_assert_int_eq(ringfs_count_exact(&fs), capacity - fs.slots_per_sector + 1);
+        cr_assert_eq(ringfs_count_exact(&fs), capacity - fs.slots_per_sector + 1);
         assert_scan_integrity(&fs);
 
         printf("## fill back up to the sector capacity\n");
         for (int i=0; i<fs.slots_per_sector-1; i++)
             ringfs_append(&fs, (int[]) { i });
 
-        ck_assert_int_eq(ringfs_count_exact(&fs), capacity);
+        cr_assert_eq(ringfs_count_exact(&fs), capacity);
         assert_scan_integrity(&fs);
     }
 }


### PR DESCRIPTION
This PR ports the existing unit tests to criterion and uses the meson build system to build  them.

The python test stuff is not touched at all.
No changes made to `ringfs`. 

Since criterion runs tests in parallel by default and the tests are setup to use the same emulated flash resource, then the tests must be run with `-j1` argument to run them in 1 process.
Example:
```
meson setup build
# either run through meson: 
meson test -C build --test-args="-j1"
# or run criterion directly:
meson compile -C build && build/test_new/test_ringfs -j1
```